### PR TITLE
Remove colons from filenames

### DIFF
--- a/sla/RADS/call_rads_noice_mad_c2file-170_20_-10_9215.m
+++ b/sla/RADS/call_rads_noice_mad_c2file-170_20_-10_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_c2file-170_20_-10_9215.m >&! call_rads_noice_mad_c2file-170_20_-10_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='c2file';years=[1992:2015];doTesting=0;l0list=[-170:20:-10];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_c2file_10_20_170_9215.m
+++ b/sla/RADS/call_rads_noice_mad_c2file_10_20_170_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nojvm -nodisplay < call_rads_noice_mad_c2file_10_20_170_9215.m >&! call_rads_noice_mad_c2file_10_20_170_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='c2file';years=[1992:2015];doTesting=0;l0list=[10:20:170];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_ersfile-170_20_-10_9215.m
+++ b/sla/RADS/call_rads_noice_mad_ersfile-170_20_-10_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_ersfile-170_20_-10_9215.m >&! call_rads_noice_mad_ersfile-170_20_-10_9215.log&
+
+startup_v4_gcmfaces
+
+choiceData='ersfile';years=[1992:2015];doTesting=0;l0list=[-170:20:-10];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0,doTesting)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_ersfile_10_20_170_9215.m
+++ b/sla/RADS/call_rads_noice_mad_ersfile_10_20_170_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_ersfile_10_20_170_9215.m >&! call_rads_noice_mad_ersfile_10_20_170_9215.log&
+
+startup_v4_gcmfaces;
+which rads_noice_mad
+choiceData='ersfile';years=[1992:2015];doTesting=0;l0list=[10:20:170];L0list=[-80:20:80];doNoice=0;
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0,0,0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_gfofile-170_20_-10_9215.m
+++ b/sla/RADS/call_rads_noice_mad_gfofile-170_20_-10_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_gfofile-170_20_-10_9215.m >&! call_rads_noice_mad_gfofile-170_20_-10_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='gfofile';doTesting=0;l0list=[-170:20:-10];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_gfofile_10_20_170_9215.m
+++ b/sla/RADS/call_rads_noice_mad_gfofile_10_20_170_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_gfofile_10_20_170_9215.m >&! call_rads_noice_mad_gfofile_10_20_170_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='gfofile';doTesting=0;l0list=[10:20:170];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_safile-170_20_-10_9215.m
+++ b/sla/RADS/call_rads_noice_mad_safile-170_20_-10_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_safile-170_20_-10_9215.m >&! call_rads_noice_mad_safile-170_20_-10_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='safile';years=[1992:2015];doTesting=0;l0list=[-170:20:-10];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_safile_10_20_170_9215.m
+++ b/sla/RADS/call_rads_noice_mad_safile_10_20_170_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nojvm -nodisplay < call_rads_noice_mad_safile_10_20_170_9215.m >&! call_rads_noice_mad_safile_10_20_170_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='safile';years=[1992:2015];doTesting=0;l0list=[10:20:170];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_topexfile-170_20_-10_9215.m
+++ b/sla/RADS/call_rads_noice_mad_topexfile-170_20_-10_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nodesktop -nodisplay < call_rads_noice_mad_topexfile-170_20_-10_9215.m >&! call_rads_noice_mad_topexfile-170_20_-10_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='topexfile';years=[1992:2015];doTesting=0;l0list=[-170:20:-10];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit

--- a/sla/RADS/call_rads_noice_mad_topexfile_10_20_170_9215.m
+++ b/sla/RADS/call_rads_noice_mad_topexfile_10_20_170_9215.m
@@ -1,0 +1,15 @@
+% To run this script in background:  
+% matlab -nojvm -nodisplay < call_rads_noice_mad_topexfile_10_20_170_9215.m >&! call_rads_noice_mad_topexfile_10_20_170_9215.log&
+
+startup_v4_gcmfaces;
+
+choiceData='topexfile';years=[1992:2015];doTesting=0;l0list=[10:20:170];L0list=[-80:20:80];
+for l0=l0list;
+l0
+for L0=L0list;
+L0
+  rads_noice_mad(choiceData,l0,L0)
+end
+end
+disp('END OF JOB')
+exit


### PR DESCRIPTION
Rename files by removing colons from filenames. Colons do not work on Windows systems. 